### PR TITLE
Count file content with `path` option

### DIFF
--- a/counter.go
+++ b/counter.go
@@ -7,13 +7,16 @@ import (
 // Counter counts the words in given string.
 func Counter(s string) int {
 	s = strings.TrimSpace(s)
-	words := strings.Split(s, " ")
+	lines := strings.Split(s, "\n")
 	counter := 0
 
-	for _, word := range words {
-		word = strings.TrimSpace(word)
-		if len(word) > 0 {
-			counter++
+	for _, line := range lines {
+		words := strings.Split(line, " ")
+		for _, word := range words {
+			word = strings.TrimSpace(word)
+			if len(word) > 0 {
+				counter++
+			}
 		}
 	}
 

--- a/counter_test.go
+++ b/counter_test.go
@@ -41,6 +41,13 @@ func TestCounter(t *testing.T) {
 			s:        "  This is   , . /   example text  - with spaces 124 ",
 			expCount: 11,
 		},
+		{
+			name: "File content with new lines",
+			s: `this is first line
+	this is second line
+		this is third line`,
+			expCount: 12,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/file.go
+++ b/file.go
@@ -1,0 +1,13 @@
+package main
+
+import "os"
+
+// ReadFile reads file content and returns as string type.
+func ReadFile(dir string) (string, error) {
+	b, err := os.ReadFile(dir)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}

--- a/main.go
+++ b/main.go
@@ -3,13 +3,37 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
 )
+
+var filePath = flag.String("path", "", "File path for counting file content")
 
 func main() {
 	flag.Parse()
 
 	s := flag.Args()
+
+	if len(s) != 0 {
+		fmt.Println("\n============================")
+		fmt.Println("Word count:", Counter(s[0]))
+		fmt.Println("============================")
+		return
+	}
+
+	if len(*filePath) == 0 {
+		// TODO Show usage
+		fmt.Println("Invalid file path.")
+		os.Exit(1)
+	}
+
+	content, err := ReadFile(*filePath)
+	if err != nil {
+		fmt.Println("Error while reading file.")
+		os.Exit(1)
+	}
+
 	fmt.Println("\n============================")
-	fmt.Println("Word count:", Counter(s[0]))
+	fmt.Println("Word count:", Counter(content))
 	fmt.Println("============================")
+
 }


### PR DESCRIPTION
* Fixes #1.
* Counting file content's word number feature added. The option is --path.
* Test case added for new line.
* Count function is updated for newline chars.
* ReadFile helper function implemented for given file directory.